### PR TITLE
fix: description for @This()

### DIFF
--- a/cheatsheet.tex
+++ b/cheatsheet.tex
@@ -464,9 +464,9 @@
 \end{mycolorbox}
 
 \begin{mycolorbox}{CtpMaroon}{BuiltIn}
-	\textbf{Get \lq filename.struct\_name\rq}
+	\textbf{Get the innermost struct/enum/union}
 	\begin{minted}[autogobble, breaklines, xleftmargin=1cm,breakafter={/}]{zig}
-		@TypeOf()
+		@This()
 	\end{minted}
 	
 	\textbf{Typeinfo:}


### PR DESCRIPTION
Replaced @TypeOf with @This, and updated the heading to match the official documentation [https://ziglang.org/documentation/master/#This].
I updated the source, but wasn't sure which TeX engine was originally used to generate the PDF.
I tried both pdflatex and lualatex, but the output differs slightly.
Feel free to regenerate the PDF using your preferred method if needed.